### PR TITLE
Add ::range-lower support for -moz-range-progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Styles the thumb of a range.
 
 #### `::range-lower`
 
-Styles the lower track of a range before the thumb. <small>*Only supported in Edge and IE 10+.*</small>
+Styles the lower track of a range before the thumb. <small>*Only supported in Firefox, Edge and IE 10+.*</small>
 
 #### `::range-upper`
 

--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@ var postcss = require('postcss');
 var prefixi = {
 	'::range-track': ['::-moz-range-track', '::-ms-track', '::-webkit-slider-runnable-track'],
 	'::range-thumb': ['::-moz-range-thumb', '::-ms-thumb', '::-webkit-slider-thumb'],
-	'::range-lower': ['::-ms-fill-lower'],
+	'::range-lower': ['::-moz-range-progress', '::-ms-fill-lower'],
 	'::range-upper': ['::-ms-fill-upper']
 };
 
 var matcherStrict = /::(range-track|range-thumb|range-upper)/i;
-var matcherLoose  = /::(range-track|range-thumb|range-upper|-moz-range-track|-ms-track|-webkit-slider-runnable-track|-moz-range-thumb|-ms-thumb|-webkit-slider-thumb|-ms-fill-lower|-ms-fill-upper)/i;
+var matcherLoose  = /::(range-track|range-thumb|range-upper|-moz-range-track|-ms-track|-webkit-slider-runnable-track|-moz-range-thumb|-ms-thumb|-webkit-slider-thumb|-moz-range-progress|-ms-fill-lower|-ms-fill-upper)/i;
 
 module.exports = postcss.plugin('postcss-input-range', function (opts) {
 	var method = opts && /^(clone|warn)$/i.test(opts.method || '') ? opts.method.toLowerCase() : 'replace';

--- a/test/fixtures/basic.clone.expect.css
+++ b/test/fixtures/basic.clone.expect.css
@@ -37,3 +37,15 @@
 	border-radius: 3px;
 	cursor: pointer;
 }
+
+::-moz-range-progress {
+	background: #78a300;
+}
+
+::-ms-fill-lower {
+	background: #78a300;
+}
+
+::range-lower {
+	background: #78a300;
+}

--- a/test/fixtures/basic.css
+++ b/test/fixtures/basic.css
@@ -7,3 +7,7 @@
 	border-radius: 3px;
 	cursor: pointer;
 }
+
+::range-lower {
+	background: #78a300;
+}

--- a/test/fixtures/basic.expect.css
+++ b/test/fixtures/basic.expect.css
@@ -39,3 +39,13 @@
 
     cursor: pointer
 }
+
+::-moz-range-progress {
+
+    background: #78a300
+}
+
+::-ms-fill-lower {
+
+    background: #78a300
+}

--- a/test/fixtures/basic.replace.expect.css
+++ b/test/fixtures/basic.replace.expect.css
@@ -39,3 +39,13 @@
 
     cursor: pointer
 }
+
+::-moz-range-progress {
+
+    background: #78a300
+}
+
+::-ms-fill-lower {
+
+    background: #78a300
+}

--- a/test/fixtures/basic.warn.expect.css
+++ b/test/fixtures/basic.warn.expect.css
@@ -7,3 +7,7 @@
 	border-radius: 3px;
 	cursor: pointer;
 }
+
+::range-lower {
+	background: #78a300;
+}

--- a/test/fixtures/vendor.css
+++ b/test/fixtures/vendor.css
@@ -7,3 +7,7 @@
 	border-radius: 3px;
 	cursor: pointer;
 }
+
+::-moz-range-progress {
+	background: #78a300;
+}

--- a/test/fixtures/vendor.expect.css
+++ b/test/fixtures/vendor.expect.css
@@ -7,3 +7,7 @@
 	border-radius: 3px;
 	cursor: pointer;
 }
+
+::-moz-range-progress {
+	background: #78a300;
+}

--- a/test/fixtures/vendor.loose.expect.css
+++ b/test/fixtures/vendor.loose.expect.css
@@ -39,3 +39,13 @@
 
     cursor: pointer
 }
+
+::-moz-range-progress {
+
+    background: #78a300
+}
+
+::-ms-fill-lower {
+
+    background: #78a300
+}

--- a/test/index.js
+++ b/test/index.js
@@ -14,7 +14,7 @@ var tests = {
 		'basic:warn': {
 			message: 'supports "warn" method',
 			options: { method: 'warn' },
-			warning: 2
+			warning: 3
 		},
 		'vendor': {
 			message: 'ignores vendor prefixes if strict'


### PR DESCRIPTION
This pull request adds the [`::-moz-range-progress`](https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-range-progress) to the list of pseudo-elements produced by the `::range-lower` selector.