### PR TITLE
Fix issue with >=3.0.0 releases 

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = postcss.plugin('postcss-input-range', ({
 			let cloned;
 
 			parser((selectors) => {
-				selectors.walk((selector) => {
+				selectors.each((selector) => {
 					selector.walkPseudos((pseudo) => {
 						Object.keys(prefixi).forEach((name) => {
 							const prefixes = strict ? [name] : prefixi[name].concat(name);


### PR DESCRIPTION
> Revert `walk` call to `each` since `walk` can be called with `ClassName` portion of the `Selector` and `walkPseudos` is not defined on the `ClassName` object hierarchy. 

We're currently writing our sass like 

```scss
.className {
   .subSelector::range-track {
      //styles
   }
}
```

Version 3 and beyond currently causes an error on build with this syntax. Reverting to the `each` call fixes the issue.

Fixes https://github.com/jonathantneal/postcss-input-range/issues/4